### PR TITLE
Bump max instances for ECS from 1 to 3 in dev

### DIFF
--- a/environments/dev/ecs/terragrunt.hcl
+++ b/environments/dev/ecs/terragrunt.hcl
@@ -8,7 +8,7 @@ dependencies {
 
 inputs = {
   instance_type = "t3.micro"
-  maximum_ec2_instances = 1
+  maximum_ec2_instances = 3
 }
 
 


### PR DESCRIPTION
Because we use the distinctInsance placement strategy, we need more than 1 instance to deploy.